### PR TITLE
removed template BOM encoding

### DIFF
--- a/JavaScriptResource.mustache
+++ b/JavaScriptResource.mustache
@@ -1,4 +1,4 @@
-﻿fiftyoneDegreesManager = function() {
+fiftyoneDegreesManager = function() {
     'use-strict';
     var json = {{&_jsonObject}};
     var parameters = {{&_parameters}};


### PR DESCRIPTION
The BOM encoding was causing an error for the JavaScript Mustache rendering engine. 

When using BOM encoding with the rendering engine, it added the ZWNBSP Unicode symbol to the output, which is not a valid symbol for the web.