### PR TITLE
BUG: Ammend the regex used to replace cookie assignment.

### DIFF
--- a/JavaScriptResource.mustache
+++ b/JavaScriptResource.mustache
@@ -191,7 +191,7 @@ fiftyoneDegreesManager = function() {
         if (jsProperties !== undefined && jsProperties.length > 0) {
 
             {{^_enableCookies}}
-            let valueSetPrefix = new RegExp('document\\.cookie\\s*=\\s*(("([A-Za-z0-9_]+)\\s*=\\s*"\\s*\\+\\s*([^\\s};]+))|(`([A-Za-z0-9_]+)\\s*=\\s*\\$\\{([^}]+)\\}`))', 'g');
+            let valueSetPrefix = new RegExp('document\\.cookie\\s*=\\s*(("([A-Za-z0-9_"\\s\\+]+)\\s*=\\s*"\\s*\\+\\s*([^\\s};]+))|(`([A-Za-z0-9_]+)\\s*=\\s*\\$\\{([^}]+)\\}`))', 'g');
             let session51DataPrefix = sessionKey + "_data_";
             let sessionSetPatch = 'window.sessionStorage["' + session51DataPrefix + '$3$6"]=$4$7';
             {{/_enableCookies}}


### PR DESCRIPTION
When 51Degrees location JavaScript is replaced, the string is not captured correctly.
The string for location is:
```
document.cookie = "51D_Pos_" + key + "=" + pos.coords[key];
```
By adding `"`, `+`, and `s*` to the captured characters for the part before the `=`, this is correctly captured and replaced, resulting in:
```
window.sessionStorage["someprefix51D_Pos_" + key + ""]=pos.coords[key];
```

A downside of capturing the joined string is the trailing `"` before the `=`. This is captured by the regex, when it would be neater not to. However, as the replacement ends in a `"`, the result is the addition of an empty string. So this seems like a pragmatic solution.