### PR TITLE
Wrap `JSON.parse` call in try-catch.

### DIFF
--- a/JavaScriptResource.mustache
+++ b/JavaScriptResource.mustache
@@ -343,7 +343,13 @@ fiftyoneDegreesManager = function() {
 {{#_updateEnabled}}
     // Process the response as json and call the resolve method.
     var loadJSON = function(resolve, reject, responseText) {
-        json = JSON.parse(responseText);
+        try {
+            json = JSON.parse(responseText);
+        } catch(err) {
+            clearCache();
+            reject(new Error("Invalid JSON - the endpoint is likely setup incorrectly", { cause: err }));
+            return;
+        }
 
         if (hasJSFunctions()) {
             // json updated so fire 'on change' functions
@@ -476,7 +482,19 @@ fiftyoneDegreesManager = function() {
 
     // Function logs errors, used to 'reject' a promise or for error callbacks.
     var catchError = function(value) {
-        console.log(value.message || value);
+		function errorToDesc(subError) {
+			let msg = subError.message;
+			if (!msg) {
+				return subError;
+			}
+			let cause = subError.cause;
+			if (cause) {
+				msg += '\n--- caused by ---\n';
+				msg += errorToDesc(cause);
+			}
+			return msg;
+		}
+        console.log(errorToDesc(value));
     }
 
     // Populate this instance of the FOD object with getters to access the

--- a/JavaScriptResource.mustache
+++ b/JavaScriptResource.mustache
@@ -20,6 +20,9 @@ fiftyoneDegreesManager = function() {
     // Set to true when the JSON object is complete.
     var completed = false;
 
+    // Set to true when the `catchError` is called.
+    let failed = false;
+
     // changeFuncs is an array of functions. When onChange is called and passed
     // a function, the function is registered and is called when processing is
     // complete.
@@ -274,6 +277,7 @@ fiftyoneDegreesManager = function() {
 
         if (started === 0) {
             executeCallback = false;
+            failed = false;
             completed = true;
         }
         if (executeCallback) {
@@ -358,6 +362,7 @@ fiftyoneDegreesManager = function() {
             fireChangeFuncs(json);
             process(resolve, reject);
         } else {
+            failed = false;
             completed = true;
             // json updated so fire 'on change' functions
             // This must happen after completed = true in order
@@ -482,10 +487,11 @@ fiftyoneDegreesManager = function() {
 
     // Function logs errors, used to 'reject' a promise or for error callbacks.
     var catchError = function(value) {
+        failed = true;
 		function errorToDesc(subError) {
 			let msg = subError.message;
 			if (!msg) {
-				return subError;
+				msg = String(subError);
 			}
 			let cause = subError.cause;
 			if (cause) {
@@ -494,7 +500,15 @@ fiftyoneDegreesManager = function() {
 			}
 			return msg;
 		}
-        console.log(errorToDesc(value));
+        let errorDesc = errorToDesc(value);
+        console.log(errorDesc);
+
+        if (json.errors === null || json.errors === undefined) {
+            json.errors = [errorDesc];
+        } else if (Array.isArray(json.errors)) {
+            json.errors.push(errorDesc);
+        }
+        fireChangeFuncs(json);
     }
 
     // Populate this instance of the FOD object with getters to access the
@@ -606,11 +620,11 @@ fiftyoneDegreesManager = function() {
         }
 
 {{/_hasDelayedProperties}}
-        if(completed){
+        if(completed || failed){
             resolve(json);
         }else{
             this.onChange(function(data) {
-                if(completed){
+                if(completed || failed){
                     resolve(data);
                 }
             })
@@ -624,6 +638,7 @@ fiftyoneDegreesManager = function() {
     this.promise.then(function(value) {
         // JSON has been updated so replace the current instance.
         update.call(parent, value);
+        failed = false;
         completed = true;
     }).catch(catchError);
 {{/_supportsPromises}}


### PR DESCRIPTION
### Changes
- Wrap `JSON.parse` call in try-catch.
- Update `catchError` to print error causes and call `fireChangeFuncs`.

### Why
- https://github.com/51Degrees/javascript-templates/issues/7